### PR TITLE
fix: #11 Code Coverage

### DIFF
--- a/internal/crypto/utils_test.go
+++ b/internal/crypto/utils_test.go
@@ -1,14 +1,13 @@
 /*
-   Copyright SecureKey Technologies Inc.
-   This file contains software code that is the intellectual property of SecureKey.
-   SecureKey reserves all rights in the code and you may not use it without written permission from SecureKey.
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
 */
 
 package crypto
 
 import (
 	"io/ioutil"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -30,42 +29,36 @@ func TestParseKey(t *testing.T) {
 			Success:  true,
 			isPriv:   true,
 			keyPath:  "../../tests/keys/did-server/ec-key.pem",
-			ErrorMsg: "",
 		},
 		{
 			Name:       "Fail Parse invalid private key format case",
 			Success:    false,
 			isPriv:     true,
 			keyContent: "invalid/content",
-			ErrorMsg:   "square/go-jose: parse error",
 		},
 		{
 			Name:       "Fail Parse empty private key content case",
 			Success:    false,
 			isPriv:     true,
 			keyContent: "",
-			ErrorMsg:   "square/go-jose: parse error, got 'asn1: syntax error: sequence truncated'",
 		},
 		{
 			Name:     "Success case for public key",
 			Success:  true,
 			isPriv:   false,
 			keyPath:  "../../tests/keys/did-server/ec-pubKey.pem",
-			ErrorMsg: "",
 		},
 		{
 			Name:       "Fail Parse invalid public key case",
 			Success:    false,
 			isPriv:     false,
 			keyContent: "invalid/content",
-			ErrorMsg:   "square/go-jose: parse error",
 		},
 		{
 			Name:       "Fail Parse empty public key content case",
 			Success:    false,
 			isPriv:     false,
 			keyContent: "",
-			ErrorMsg:   "square/go-jose: parse error, got 'asn1: syntax error: sequence truncated'",
 		},
 	}
 
@@ -90,7 +83,6 @@ func TestParseKey(t *testing.T) {
 				_, err = ParsePublicKey([]byte(tc.keyContent))
 			}
 			require.Error(t, err, "parsing invalid key should return an error")
-			require.True(t, strings.HasPrefix(err.Error(), tc.ErrorMsg), "parse key error message mismatch want error starting with %s, but got %s", tc.ErrorMsg, err.Error())
 		})
 	}
 }


### PR DESCRIPTION
Fixes #11 

* Removed unused code in `internal/crypto/utils`
* Removed check for error messages in the tests since there are no dependency on the contents of these messages

Signed-off-by: George Aristy <george.aristy@securekey.com>