### PR TITLE
feat: #14 Add DID Doc API

### DIFF
--- a/internal/did/doc.go
+++ b/internal/did/doc.go
@@ -1,0 +1,81 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package did
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+)
+
+// Doc is a DID document as defined in the Decentralized Identifiers spec:
+// https://w3c-ccg.github.io/did-spec.
+type Doc struct {
+	json map[string]interface{}
+}
+
+// PublicKey is a key defined in the DID document's 'publicKey' attribute.
+// TODO PublicKey: add support for the various key contents as per the spec (eg. publicKeyPem, publicKeyBase58, etc)
+type PublicKey struct {
+	json map[string]interface{}
+}
+
+// NewDoc reads the contents into a new DID document.
+func NewDoc(contents io.Reader) (*Doc, error) {
+	bytes, err := ioutil.ReadAll(contents)
+	if err != nil {
+		return nil, err
+	}
+	doc := make(map[string]interface{})
+	if err := json.Unmarshal(bytes, &doc); err != nil {
+		return nil, err
+	}
+	return &Doc{json: doc}, nil
+}
+
+// ID returns the DID document's id.
+func (d *Doc) ID() string {
+	return toString(d.json["id"])
+}
+
+// Keys returns the DID document's set of keys.
+func (d *Doc) Keys() []*PublicKey {
+	keys := make([]*PublicKey, 0)
+	if array, ok := d.json["publicKey"].([]interface{}); ok {
+		for _, untyped := range array {
+			if json, ok := untyped.(map[string]interface{}); ok {
+				keys = append(keys, &PublicKey{json: json})
+			}
+		}
+	}
+	return keys
+}
+
+// ID returns the key's id.
+func (pk *PublicKey) ID() string {
+	return toString(pk.json["id"])
+}
+
+// Type returns the key's type.
+func (pk *PublicKey) Type() string {
+	return toString(pk.json["type"])
+}
+
+// Controller returns the key's controller.
+func (pk *PublicKey) Controller() string {
+	return toString(pk.json["controller"])
+}
+
+// Casts untyped into a string and returns it.
+// Panics if it cannot be casted to a string.
+func toString(untyped interface{}) string {
+	if s, ok := untyped.(string); ok {
+		return s
+	}
+	panic(fmt.Errorf("cannot cast %+v to string", untyped))
+}

--- a/internal/did/doc_test.go
+++ b/internal/did/doc_test.go
@@ -1,0 +1,86 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package did
+
+import (
+	"encoding/json"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"strings"
+	"testing"
+)
+
+func TestNewDoc(t *testing.T) {
+	doc, err := NewDoc(strings.NewReader(`
+		{
+  			"id": "did:example:123456789abcdefghi",
+			"publicKey": [{
+    			"id": "did:example:123456789abcdefghi#keys-1",
+    			"type": "RsaVerificationKey2018",
+				"controller": "did:example:123456789abcdefghi"
+  			}, {
+    			"id": "did:example:123456789abcdefghi#keys-2",
+    			"type": "Ed25519VerificationKey2018",
+    			"controller": "did:example:pqrstuvwxyz0987654321"
+  			}]
+		}
+	`))
+	require.NoError(t, err)
+	assert.Equal(t, "did:example:123456789abcdefghi", doc.ID())
+	assert.Len(t, doc.Keys(), 2)
+}
+
+func TestNewDocInvalidJson(t *testing.T) {
+	_, err := NewDoc(strings.NewReader("invalid"))
+	require.Error(t, err)
+}
+
+func TestDocID(t *testing.T) {
+	doc := &Doc{
+		json: toJson(t, `{ "id": "did:example:123456789abcdefghi" }`),
+	}
+	assert.Equal(t, "did:example:123456789abcdefghi", doc.ID())
+}
+
+func TestDocPublicKeysLength(t *testing.T) {
+	doc:= &Doc{json: toJson(t, `
+		{
+  			"id": "did:example:123456789abcdefghi",
+			"publicKey": [{
+    			"id": "did:example:123456789abcdefghi#keys-1",
+    			"type": "RsaVerificationKey2018",
+				"controller": "did:example:123456789abcdefghi"
+  			}, {
+    			"id": "did:example:123456789abcdefghi#keys-2",
+    			"type": "Ed25519VerificationKey2018",
+    			"controller": "did:example:pqrstuvwxyz0987654321"
+  			}]
+		}
+	`)}
+	assert.Len(t, doc.Keys(), 2)
+}
+
+func TestPublicKey(t *testing.T) {
+	key := &PublicKey{json: toJson(t, `
+		{
+    		"id": "did:example:123456789abcdefghi#keys-1",
+    		"type": "RsaVerificationKey2018",
+			"controller": "did:example:123456789abcdefghi"
+  		}`,
+	)}
+	assert.Equal(t, "did:example:123456789abcdefghi#keys-1", key.ID())
+	assert.Equal(t, "RsaVerificationKey2018", key.Type())
+	assert.Equal(t, "did:example:123456789abcdefghi", key.Controller())
+}
+
+func toJson(t *testing.T, raw string) map[string]interface{} {
+	jsonld := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(raw), &jsonld); err != nil {
+		require.NoError(t, err)
+	}
+	return jsonld
+}


### PR DESCRIPTION
Closes #14:

* Initial API that parses DID docs and reads key metadata.
* Pending support for reading the key's contents.

Signed-off-by: George Aristy <george.aristy@securekey.com>