### PR TITLE
feat: Service layer for collection store 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@
 module github.com/trustbloc/hub-store
 
 require (
+	github.com/google/uuid v1.1.1
 	github.com/pkg/errors v0.8.1
 	github.com/sirupsen/logrus v1.4.2
 	github.com/square/go-jose v0.0.0-20190531155156-ba5998847dec

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,8 @@
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/google/uuid v1.1.1 h1:Gkbcsh/GbpXz7lPftLA3P6TYMwjCLYm83jiFQZF/3gY=
+github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1 h1:mweAR1A6xJ3oS2pRaGiHgQ4OO8tzTaLawm8vnODuwDk=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=

--- a/internal/db/collection/collection.go
+++ b/internal/db/collection/collection.go
@@ -1,0 +1,37 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package collection
+
+import (
+	"github.com/trustbloc/hub-store/internal/db"
+	"github.com/trustbloc/hub-store/internal/server/models"
+)
+
+// Store defines methods for interacting with the backing db for the identity hub.
+type Store interface {
+	// Write writes the commit to the store.
+	Write(commit *models.Commit) error
+
+	// CommitQuery returns all commits (or the subset specified with the 'Revs' or 'CommitOp' filters) for a
+	// single object.
+	//
+	// Pagination is achieved with a combination of paging options 'PageSize', 'SkipToken' and the 'token' return
+	// parameter.
+	//
+	// 'token' is an opaque token to be used to fetch a subsequent page, if there's any.
+	CommitQuery(oid string, f *Filter, p *db.Paging) (commits []*models.Commit, token string, err error)
+}
+
+// Filter is a set of criteria that narrows down the results of query methods.
+type Filter struct {
+	// Constrain the search to these object IDs.
+	Oids []string
+	// Constrain the search to these revision IDs.
+	Revs []string
+	// ObjectQuery filters that match on a commit's metadata.
+	MetadataFilters []*models.Filter
+}

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -1,0 +1,16 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package db
+
+// Paging is a generic set of options that control paging in store queries that support it.
+type Paging struct {
+	// Page size.
+	Size int
+	// Set the SkipToken to the one returned by the store in order to fetch the next page
+	// of results.
+	SkipToken string
+}

--- a/internal/server/collection/collection.go
+++ b/internal/server/collection/collection.go
@@ -1,0 +1,84 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package collection
+
+import (
+	"fmt"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/trustbloc/hub-store/internal"
+	"github.com/trustbloc/hub-store/internal/db"
+	"github.com/trustbloc/hub-store/internal/db/collection"
+	"github.com/trustbloc/hub-store/internal/server"
+	"github.com/trustbloc/hub-store/internal/server/models"
+)
+
+//ServiceRequest handles the filtered request according to its request type
+func ServiceRequest(config *server.Config, request *models.Request) (*models.Response, *models.ErrorResponse) {
+	switch request.Type {
+	case "WriteRequest":
+		return doWrite(config, request.Commit)
+	default:
+		return nil, badRequest("unsupported request type", request.Type)
+	}
+}
+
+func doWrite(config *server.Config, commit *models.Commit) (*models.Response, *models.ErrorResponse) {
+	if err := config.CollectionStore.Write(commit); err != nil {
+		msg := fmt.Sprintf("failed to commit to store: %s", err)
+		log.Error(msg)
+		return nil, serverError(msg)
+	}
+	oid, err := internal.ObjectID(commit)
+	if err != nil {
+		return nil, serverError(err.Error())
+	}
+	commits, _, err := config.CollectionStore.CommitQuery(
+		oid,
+		&collection.Filter{},
+		&db.Paging{},
+	)
+	if err != nil {
+		msg := fmt.Sprintf("failed to query commits from store: %s", err)
+		log.Error(msg)
+		return nil, serverError(msg)
+	}
+	revs := make([]string, len(commits))
+	for i, c := range commits {
+		revs[i] = c.Header.Revision
+	}
+	wr := writeResponse(revs)
+	response := &models.Response{WriteResponse: wr}
+	return response, nil
+}
+
+// "bad_request" error response
+func badRequest(msg string, target string) *models.ErrorResponse {
+	return errResponse(msg, "bad_request", target)
+}
+
+// "server_error" error response
+func serverError(msg string) *models.ErrorResponse {
+	return errResponse(msg, "server_error", "")
+}
+
+func writeResponse(revs []string) *models.WriteResponse {
+	var context = "https://schema.identity.foundation/0.1"
+	return &models.WriteResponse{
+		BaseResponse: models.BaseResponse{
+			AtContextField:        context,
+			AtType:                "WriteResponse",
+			DeveloperMessageField: ""},
+		Revisions: revs}
+}
+func errResponse(msg, errCode, target string) *models.ErrorResponse {
+	er := &models.ErrorResponse{}
+	er.ErrorCode = errCode
+	er.DeveloperMessageField = msg
+	er.Target = target
+	return er
+}

--- a/internal/server/collection/collection_test.go
+++ b/internal/server/collection/collection_test.go
@@ -1,0 +1,155 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package collection
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"github.com/stretchr/testify/require"
+	"strings"
+	"testing"
+
+	"github.com/trustbloc/hub-store/internal/db"
+	"github.com/trustbloc/hub-store/internal/db/collection"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/trustbloc/hub-store/internal/server"
+	"github.com/trustbloc/hub-store/internal/server/models"
+)
+
+// standard @context
+var difContext = "https://schema.identity.foundation/0.1"
+
+const pageSize = 1
+
+// Hub Store must return a WriteResponse that includes the model's known revisions.
+func TestWriteRequest(t *testing.T) {
+	collectionStore := NewMockCollectionStore(nil)
+	serverConfig := server.Config{PageSize: pageSize, CollectionStore: collectionStore}
+	request := newWriteRequest("Collections", "http://schema.org", "MusicPlaylist")
+	writeResponse := &models.Response{}
+	err := &models.ErrorResponse{}
+	writeResponse, err = ServiceRequest(&serverConfig, request)
+    require.Nil(t, err)
+	assert.Equal(t, difContext, writeResponse.AtContextField)
+	assert.Equal(t, "WriteResponse", writeResponse.AtType)
+	assert.Contains(t, writeResponse.Revisions, request.Commit.Header.Revision)
+}
+
+func TestInvalidWriteRequest(t *testing.T) {
+	collectionStore := NewMockCollectionStore(nil)
+	serverConfig := server.Config{PageSize: pageSize, CollectionStore: collectionStore}
+	request := &models.Request{Type: "InvalidRequest"}
+	writeResponse, err := ServiceRequest(&serverConfig, request)
+	assert.Nil(t, writeResponse)
+	assert.Equal(t, err.ErrorCode, "bad_request")
+	assert.Equal(t, err.DeveloperMessageField, "unsupported request type")
+}
+
+// Hub Store must return a standard ErrorResponse with correct headers and error_code when WriteRequest fails internally.
+func TestWriteRequestError(t *testing.T) {
+	testErr := errors.New("mock store not available")
+	collectionStore := NewMockCollectionStore(testErr)
+	serverConfig := server.Config{PageSize: pageSize, CollectionStore: collectionStore}
+	request := newWriteRequest("Collections", "http://schema.org", "MusicPlaylist")
+	writeResponse, err := ServiceRequest(&serverConfig, request)
+	assert.Nil(t, writeResponse)
+	assert.NotNil(t, err)
+	assert.Equal(t, "server_error", err.ErrorCode)
+	assert.Equal(t, "failed to commit to store: mock store not available", err.DeveloperMessageField)
+}
+
+func newWriteRequest(iface, ctx, tpe string) *models.Request {
+	req := &models.Request{}
+
+	protected := fmt.Sprintf(`{
+		    "interface": "%s",
+			"context": "%s",
+			"type": "%s",
+			"operation": "create",
+			"committed_at": "2018-10-24T18:39:10.10:00Z",
+			"commit_strategy": "basic",
+			"sub": "did:example:abc123",
+			"kid": "did:example:123456#key-abc",
+			"meta": {
+			"name": "Sample playlist"
+		}
+	}`, iface, ctx, tpe)
+
+	payload := `{
+		    "@context": "http://identity.foundation",
+			"@type": "MusicPlaylist",
+			"@id": "foo",
+			"name": "A playlist"
+	}`
+	//Request commit has encoded protected and payload
+	err := json.NewDecoder(strings.NewReader(fmt.Sprintf(
+		`{
+            "@context": "https://schema.identity.foundation/0.1",
+            "@type": "WriteRequest",
+            "iss": "did:example:123456",
+            "aud": "did:example:some-hub",
+            "sub": "did:example:abc123",
+            "commit": {
+				"protected": "%s",
+                "header": {
+                    "rev": "%s",
+                    "iss": "did:example:123456"
+                },
+                "payload": "%s",
+                "signature": "j3irpj90af992l"
+            }
+        }`, encoding([]byte(protected)), randomString(), encoding([]byte(payload)),
+	))).Decode(req)
+	if err != nil {
+		panic(fmt.Sprintf("failed to decode test request: %s", err))
+	}
+	return req
+}
+func encoding(input []byte) string {
+	return base64.StdEncoding.EncodeToString(input)
+}
+func randomString() string {
+	return strings.Replace(uuid.New().String(), "-", "", -1)
+}
+
+// MockCollectionStore  mocks collection.Store. for testing purposes.
+type MockCollectionStore struct {
+	// Commit cache.
+	commit map[string][]*models.Commit
+	Err    error
+}
+
+// NewMockCollectionStore creates mock for collection store
+func NewMockCollectionStore(err error) *MockCollectionStore {
+	return &MockCollectionStore{commit: make(map[string][]*models.Commit), Err: err}
+}
+
+//Write mocks storing operations
+func (m *MockCollectionStore) Write(c *models.Commit) error {
+	if m.Err != nil {
+		return m.Err
+	}
+	keyRevision := c.Header.Revision
+	m.commit[keyRevision] = append(m.commit[keyRevision], c)
+	return nil
+}
+
+//CommitQuery mocks committing query operations
+func (m *MockCollectionStore) CommitQuery(oid string, f *collection.Filter, p *db.Paging) ([]*models.Commit, string, error) {
+	if m.Err != nil {
+		return nil, "", m.Err
+	}
+	if commits, ok := m.commit[oid]; ok {
+		return commits, "", nil
+
+	}
+	return nil, "", errors.New("revision not found in the collection store")
+}

--- a/internal/server/models/models.go
+++ b/internal/server/models/models.go
@@ -1,0 +1,93 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package models
+
+// Operation is the string which represents the type of action that the user can perform on the hub-store
+type Operation string
+
+const (
+	// Create is the action string used to create new objects by the user
+	Create Operation = "create"
+)
+
+// Meta provides the basic info about the payload
+type Meta struct {
+	Name string `json:"name,omitempty"`
+}
+
+// Protected gives the commit info and it is signature protected
+type Protected struct {
+	Interface      string    `json:"interface"`
+	Context        string    `json:"context"`
+	Type           string    `json:"type"`
+	Operation      Operation `json:"operation"`
+	CommittedAt    string    `json:"committed_at"`
+	CommitStrategy string    `json:"commit_strategy"`
+	Sub            string    `json:"sub"`
+	Kid            string    `json:"kid"`
+	ObjectID       string    `json:"object_id,omitempty"`
+	Meta           *Meta     `json:"meta,omitempty"`
+}
+
+//Header defines the header parameters for Request
+type Header struct {
+	Revision string `json:"rev"`
+	Iss      string `json:"iss"`
+}
+
+// Commit gives the actual user data
+type Commit struct {
+	Protected string  `json:"protected"`
+	Header    *Header `json:"header"`
+	Payload   string  `json:"payload"`
+	Signature string  `json:"signature"`
+}
+
+// Request is the overall request of the user
+type Request struct {
+	Context  string  `json:"@context"`
+	Type     string  `json:"@type"`
+	Issuer   string  `json:"iss"`
+	Subject  string  `json:"sub"`
+	Audience string  `json:"aud"`
+	Commit   *Commit `json:"commit"`
+}
+
+// Response encapsulates different type of responses. For example: write Response CommitQuery Response etc
+type Response struct {
+	*WriteResponse
+}
+
+// WriteResponse entails Base Response fields and revisions of commit along with optional skip token.
+type WriteResponse struct {
+	BaseResponse
+	Revisions []string `json:"revisions"`
+	SkipToken string   `json:"skip_token,omitempty"`
+}
+
+// BaseResponse defines the common parameters used by all different types of response.
+type BaseResponse struct {
+	AtContextField        string
+	AtType                string
+	DeveloperMessageField string
+}
+
+// Filter defines the parameters for applying filters while doing commit query on the collections store
+type Filter struct {
+	Field string `json:"field"`
+	Type  string `json:"type"`
+	Value string `json:"value"`
+}
+
+// ErrorResponse defines the struct to handle errors
+type ErrorResponse struct {
+	DeveloperMessageField string
+	ErrorCode             string `json:"error_code"`
+	ErrorURL              string `json:"error_url,omitempty"`
+	Target                string `json:"target"`
+	UserMessage           string `json:"user_message,omitempty"`
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1,0 +1,17 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package server
+
+import "github.com/trustbloc/hub-store/internal/db/collection"
+
+// Config is a holder for the identity hub's configuration.
+type Config struct {
+	// PageSize configures the page size to use for paged queries.
+	PageSize int
+	// Collection store.
+	CollectionStore collection.Store
+}

--- a/internal/util.go
+++ b/internal/util.go
@@ -1,0 +1,40 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package internal
+
+import (
+	"encoding/base64"
+	"encoding/json"
+
+	"github.com/trustbloc/hub-store/internal/server/models"
+)
+
+// ObjectID returns the ID of the object that this commit either creates or modifies.
+// For "create" commits, the object's ID is the commit's revision (commit.header.rev).
+// For "update" or "delete" commits, the object's ID is explicitly presented as commit.protected.object_id.
+func ObjectID(commit *models.Commit) (string, error) {
+	var oid string
+	protected := models.Protected{}
+	decodedBytes, err := decoding(commit.Protected)
+	if err != nil {
+		return "", err
+	}
+	err = json.Unmarshal(decodedBytes, &protected)
+	if err != nil {
+		return "", err
+	}
+	if protected.Operation == models.Create {
+		oid = commit.Header.Revision
+	} else {
+		oid = protected.ObjectID
+	}
+	return oid, nil
+}
+
+func decoding(input string) ([]byte, error) {
+	return base64.StdEncoding.DecodeString(input)
+}

--- a/internal/util_test.go
+++ b/internal/util_test.go
@@ -1,0 +1,57 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package internal
+
+import (
+	"encoding/base64"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/trustbloc/hub-store/internal/server/models"
+)
+
+func TestObjectIdOfWithCreateCommit(t *testing.T) {
+	const rev = "abc123"
+	commit := &models.Commit{}
+	protected := `{
+			"operation": "create"
+		}`
+	commit.Protected = encoding([]byte(protected))
+	commit.Header = &models.Header{Revision: rev}
+	oid, err := ObjectID(commit)
+	assert.Nil(t, err)
+	assert.Equal(t, rev, oid, "ObjectID() must return commit.header.revision of create commit")
+}
+
+func TestObjectIdOfWithUpdateCommit(t *testing.T) {
+	const rev = "abc123"
+	commit := &models.Commit{}
+	protected := fmt.Sprintf(`{
+			"operation": "update",
+            "object_id" :  "%s"
+		}`, rev )
+	commit.Protected = encoding([]byte(protected))
+	commit.Header = &models.Header{Revision: "999999999"}
+	oid, err := ObjectID(commit)
+	assert.Nil(t, err)
+	assert.Equal(t, rev, oid, "ObjectID() must return commit.protected.object_id of update commit")
+}
+func TestObjectIdOfWithInvalidDecode(t *testing.T) {
+	commit := &models.Commit{}
+	protected := `{
+			"test": "create"
+		`
+	commit.Protected = encoding([]byte(protected))
+	oid, err := ObjectID(commit)
+	assert.NotNil(t, err)
+	assert.Equal(t, "", oid)
+	assert.Equal(t, "unexpected end of JSON input", err.Error())
+}
+func encoding(input []byte) string {
+	return base64.StdEncoding.EncodeToString(input)
+}


### PR DESCRIPTION
Closes #20
Create a service layer for collection store
-Adding a commit to the store and performing commitQuery to get an array of
 revisions.
-Limited to single write request for the this PR
-Mock Collection store which stores the commit json with the key as commit.header.Revision
-Models for handling input request from the handler

Signed-off-by: talwinder.kaur <talwinder.kaur@securekey.com>